### PR TITLE
Update KeepAliveTimeout from 300 to 5

### DIFF
--- a/docs/src/main/asciidoc/quickstart.adoc
+++ b/docs/src/main/asciidoc/quickstart.adoc
@@ -129,7 +129,7 @@ LoadModule advertise_module /opt/jboss/httpd/lib/httpd/modules/mod_advertise.so
      Require ip 127.0.0
     </Location>
 
-    KeepAliveTimeout 300
+    KeepAliveTimeout 5
     MaxKeepAliveRequests 0
     #ServerAdvertise on http://@IP@:6666
     AdvertiseFrequency 5


### PR DESCRIPTION
Setting KeepAliveTimeout to a high value may cause performance problems in heavily loaded servers. The higher the timeout, the more server processes will be kept occupied waiting on connections with idle clients.

https://httpd.apache.org/docs/2.4/mod/core.html#keepalivetimeout