### PR TITLE
clarify mod_cluster / mod_proxy_cluster.

### DIFF
--- a/docs/src/main/asciidoc/introduction.adoc
+++ b/docs/src/main/asciidoc/introduction.adoc
@@ -22,14 +22,9 @@ mod_proxy_ajp provides all the AJP logic needed by mod_cluster.
 [[platforms]]
 == Platforms
 
-JBoss already prepares https://github.com/modcluster/mod_cluster/releases[binary
-packages] with httpd
-and mod_cluster so you can quickly try mod_cluster on the following
-platforms:
+The binary packages of the modules needed to use with Apache httpd server are present in most ditribution.
 
-* Linux x86, x64, ia64
-* Solaris x86, SPARC
-* Windows x86, x64, ia64
+If your distribution doesn't have mod_cluster or mod_proxy_cluster pick the latest 1.3.x released tar.gz and follow the building instructions.
 
 [[advantages]]
 == Advantages
@@ -56,7 +51,7 @@ The original concepts are described in a http://www.jboss.org/community/docs/DOC
 
 === Balancer side
 
-* Apache HTTP Server 2.2.15+ (legacy 2.2.8+)
+* Apache HTTP Server 2.4.37+
 
 === Worker side
 
@@ -86,10 +81,12 @@ mod_cluster uses shared memory to keep the nodes description, the shared memory 
 
 Download the latest https://modcluster.io/downloads/[mod_cluster release].
 
-The release is comprised of the following artifacts:
+The release contains the source to build the following:
 
-* httpd binaries for common platforms
-* WildFly/JBoss AS/JBossWeb/Tomcat Java distribution
+* WildFly/JBoss AS/Tomcat Java distributions
+
+The native part is developed in https://github.com/modcluster/mod_proxy_cluster and https://github.com/modcluster/mod_cluster/tree/1.3.x
+The native part is compatible with the 2.0.x and 1.4.x branches of mod_cluster
 
 Alternatively, you can build from source using the https://github.com/modcluster/mod_cluster[mod_cluster git repository] and https://github.com/modcluster/mod_proxy_cluster[mod_proxy_cluster git repository].
 


### PR DESCRIPTION
Clarify the version to use between mod_cluster (java) and mod_proxy_cluster (c/native).