### PR TITLE
Make docs a bit more up-to-date

### DIFF
--- a/docs/src/main/asciidoc/container-integration.adoc
+++ b/docs/src/main/asciidoc/container-integration.adoc
@@ -673,7 +673,7 @@ Each load metric contributes a value to the overall load factor of a
 node. The load factors from each metric are aggregated according to
 their weights.
 
-In general, the load factor contribution of given metric is: `(load /
+In general, the load factor contribution of a given metric is: `(load /
 capacity) \* weight / total weight`.
 
 The DynamicLoadBalanceFactorProvider applies a time decay function to

--- a/docs/src/main/asciidoc/introduction.adoc
+++ b/docs/src/main/asciidoc/introduction.adoc
@@ -3,48 +3,65 @@
 
 NOTE: {editurl}introduction.adoc[{editnote}]
 
-mod_cluster is an httpd-based load balancer. Like mod_jk and
+Project mod_cluster is an intelligent load balancer. Like mod_jk and
 mod_proxy, mod_cluster uses a communication channel to forward
 requests from httpd to one of a set of application server nodes. Unlike
-mod_jk and mod_proxy, mod_cluster leverages an additional connection
+mod_jk and mod_proxy, mod_proxy_cluster leverages an additional connection
 between the application server nodes and httpd. The application server
 nodes use this connection to transmit server-side load balance factors
 and lifecycle events back to httpd via a custom set of HTTP methods,
 affectionately called the Mod-Cluster Management Protocol (MCMP). This
-additional feedback channel allows mod_cluster to offer a level of
+additional feedback channel allows mod_proxy_cluster to offer a level of
 intelligence and granularity not found in other load balancing
 solutions.
 
-Within httpd, mod_cluster is implemented as a set of modules for httpd
+Within httpd, mod_proxy_cluster is implemented as a set of modules for httpd
 with mod_proxy enabled. Much of the logic comes from mod_proxy, e.g.
-mod_proxy_ajp provides all the AJP logic needed by mod_cluster.
+mod_proxy_ajp provides all the AJP logic needed by mod_proxy_cluster.
+
+NOTE: In the past, mod_proxy_cluster was known as mod_cluster (version 1.3.x and older),
+consisting of native and container implementations. The repositories of the two
+implementations were separated, and the native part got the name mod_proxy_cluster, while
+the former name mod_cluster is currently used for container implementation.
 
 [[platforms]]
 == Platforms
 
-The binary packages of the modules needed to use with Apache httpd server are present in most ditribution.
+The binary packages of the modules needed to use with Apache httpd server are present in most distributions.
 
-If your distribution doesn't have mod_cluster or mod_proxy_cluster pick the latest 1.3.x released tar.gz and follow the building instructions.
+If your distribution doesn't provide mod_proxy_cluster, pick the latest version from the source and follow
+the building instructions.
 
 [[advantages]]
 == Advantages
-mod_cluster boasts the following advantages over other httpd-based load balancers:
+mod_proxy_cluster boasts the following advantages over other httpd-based load balancers:
 
 * Dynamic configuration of httpd workers
 
-Traditional httpd-based load balancers require explicit configuration of the workers available to a proxy. In mod_cluster, the bulk of the proxy's configuration resides on the application servers. The set of proxies to which an application server will communicate is determined either by a static list or using dynamic discovery via the advertise mechanism. The application server relays lifecycle events (e.g. server startup/shutdown) to the proxies allowing them to effectively auto-configure themselves. Notably, the graceful shutdown of a server will not result in a failover response by a proxy, as is the case with traditional httpd-based load balancers.
+Traditional httpd-based load balancers require explicit configuration of the workers available to a proxy.
+In mod_proxy_cluster, the bulk of the proxy's configuration resides on the application servers. The set of
+proxies to which an application server will communicate is determined either by a static list or using dynamic
+discovery via the advertising mechanism. The application server relays lifecycle events (e.g. server startup/shutdown)
+to the proxies allowing them to effectively auto-configure themselves. Notably, the graceful shutdown of a server
+will not result in a failover response by a proxy, as is the case with traditional httpd-based load balancers.
 
 * Server-side load balance factor calculation
 
-In contrast with traditional httpd-based load balancers, mod_cluster uses load balance factors calculated and provided by the application servers, rather than computing these in the proxy. Consequently, mod_cluster offers a more robust and accurate set of load metrics than is available from the proxy (see Load Metrics for more).
+In contrast with traditional httpd-based load balancers, mod_proxy_cluster uses load balance factors calculated and
+provided by the application servers rather than computing these in the proxy. Consequently, mod_proxy_cluster offers
+a more robust and accurate set of load metrics than is available from the proxy (see Load Metrics for more).
 
 * Fine grained web-app lifecycle control
 
-Traditional httpd-based load balancers do not handle web application undeployments particularly well. From the proxy's perspective requests to an undeployed web application are indistinguishable from a request for an non-existent resource, and will result in 404 errors. In mod_cluster, each server forwards any web application context lifecycle events (e.g. web-app deploy/undeploy) to the proxy informing it to start/stop routing requests for a given context to that server.
+Traditional httpd-based load balancers do not handle web application undeployments particularly well. From the proxy's
+perspective, requests to an undeployed web application are indistinguishable from a request for a non-existent
+resource and will result in 404 errors. In mod_cluster, each server forwards any web application context lifecycle
+events (e.g. web-app deploy/undeploy) to the proxy, informing it to start/stop routing requests for a given context to
+that server.
 
 * AJP is optional
 
-Unlike mod_jk, mod_cluster does not require AJP. httpd connections to application server nodes can use HTTP, HTTPS, or AJP.
+Unlike mod_jk, mod_proxy_cluster does not require AJP. httpd connections to application server nodes can use HTTP, HTTPS, or AJP.
 The original concepts are described in a http://www.jboss.org/community/docs/DOC-11431[wiki].
 
 == Requirements
@@ -63,7 +80,8 @@ The mod_cluster container integration module (implemented in Java) is provided f
 
 == Limitations
 
-mod_cluster uses shared memory to keep the nodes description, the shared memory is created at the start of httpd and the structure of each item is fixed. The following cannot be changed by configuration directives.
+mod_proxy_cluster uses shared memory to keep the nodes description, the shared memory is created at the start of httpd and
+the structure of each item is fixed. The following cannot be changed by configuration directives.
 
 * Max Alias length 40 characters (Host: hostname header, Alias in&lt;Host/&gt;).
 * Max context length 40 (for example myapp.war deploys in /myapp/myapp is the context).
@@ -85,10 +103,12 @@ The release contains the source to build the following:
 
 * WildFly/JBoss AS/Tomcat Java distributions
 
-The native part is developed in https://github.com/modcluster/mod_proxy_cluster and https://github.com/modcluster/mod_cluster/tree/1.3.x
+The native part is developed in https://github.com/modcluster/mod_proxy_cluster (with 1.3.x version and older
+available in the original repository https://github.com/modcluster/mod_cluster/tree/1.3.x).
 The native part is compatible with the 2.0.x and 1.4.x branches of mod_cluster
 
-Alternatively, you can build from source using the https://github.com/modcluster/mod_cluster[mod_cluster git repository] and https://github.com/modcluster/mod_proxy_cluster[mod_proxy_cluster git repository].
+Alternatively, you can build from source using the https://github.com/modcluster/mod_cluster[mod_cluster git repository]
+and https://github.com/modcluster/mod_proxy_cluster[mod_proxy_cluster git repository].
 
 == Configuration
 
@@ -115,5 +135,10 @@ link:#UsingSSL[mod_ssl module] and link:#worker_config[explicit configuration in
 
 mod_cluster contains mod_ssl, therefore the warning (copied from OpenSSL https://www.openssl.org/[web site]).
 
-WARNING: Strong cryptography: Please remember that export/import and/or use of strong cryptography software, providing cryptography hooks, or even just communicating technical details about cryptography software is illegal in some parts of the world. So when you import this package to your country, re-distribute it from there or even just email technical suggestions or even source patches to the authors or other people you are strongly advised to pay close attention to any laws or regulations which apply to you. The authors of openssl are not liable for any violations you make here. So be careful, it is your responsibility.
+WARNING: Strong cryptography: Please remember that export/import and/or use of strong cryptography software, providing
+cryptography hooks, or even just communicating technical details about cryptography software is illegal in some parts
+of the world. So when you import this package to your country, re-distribute it from there or even just email technical
+suggestions or even source patches to the authors or other people you are strongly advised to pay close attention to
+any laws or regulations which apply to you. The authors of openssl are not liable for any violations you make here. So
+be careful, it is your responsibility.
 

--- a/docs/src/main/asciidoc/native.adoc
+++ b/docs/src/main/asciidoc/native.adoc
@@ -5,7 +5,7 @@ NOTE: {editurl}native.adoc[{editnote}]
 
 == Apache httpd configuration
 
-You need to load the modules that are needed for mod_cluster for example:
+You need to load the modules that are needed for mod_proxy_cluster for example:
 
 [source]
 ----
@@ -17,24 +17,25 @@ LoadModule proxy_cluster_module modules/mod_proxy_cluster.so
 LoadModule advertise_module modules/mod_advertise.so
 ----
 
-NOTE: *mod_cluster 1.2.x vs mod_cluster 1.3.x:* Note that from mod_cluster 1.3.x on, the slotmem module is called
-`LoadModule cluster_slotmem_module modules/mod_cluster_slotmem.so` instead of former `LoadModule slotmem_module modules/mod_slotmem.so`.
+NOTE: *mod_cluster 1.2.x and older:* Note that mod_cluster 1.2.x and older used different
+name for the slotmem module (`LoadModule slotmem_module modules/mod_slotmem.so` instead of
+the current `LoadModule cluster_slotmem_module modules/mod_cluster_slotmem.so`).
 
-mod_proxy and mod_proxy_ajp are standard httpd modules. mod_slotmem is a shared slotmem memory provider.
-mod_manager is the module that reads information from JBoss AS/JBossWeb/Tomcat and updates the shared memory
-information. mod_proxy_cluster is the module that contains the balancer for mod_proxy. mod_advertise is an
-additional module that allows httpd to advertise via multicast packets the IP and port where the mod_cluster
-is listening. This multi-module architecture allows the modules to easily be changed depending on what the
-customer wants to do.
+mod_proxy and mod_proxy_ajp are standard httpd modules. mod_cluster_slotmem is a shared slotmem
+memory provider. mod_manager is the module that reads information from JBoss AS/JBossWeb/Tomcat
+and updates the shared memory information. mod_proxy_cluster is the module that contains the
+balancer for mod_proxy. mod_advertise is an additional module that allows httpd to advertise via
+multicast packets the IP and port where the mod_proxy_cluster is listening. This multi-module
+architecture allows the modules to easily be changed depending on what the customer wants to do.
 
-For example when using http instead of AJP, only
+For example when using http instead of AJP, only:
 
 [source]
 ----
 LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 ----
 
-needs to be changed to:
+has to be changed to:
 
 [source]
 ----
@@ -43,18 +44,18 @@ LoadModule proxy_http_module modules/mod_proxy_http.so
 
 == mod_proxy configuration
 
-mod_proxy directives like ProxyIOBufferSize could be used to configure mod_cluster. There is no need to use ProxyPass
-directives because mod_cluster automatically configures which URLs have to be forwarded to JBossWEB.
+mod_proxy directives like ProxyIOBufferSize could be used to configure mod_proxy_cluster. There is no need to use ProxyPass
+directives because mod_proxy_cluster automatically configures which URLs have to be forwarded to JBossWEB.
 
-== mod_slotmem/cluster_slotmem_module configuration
+== mod_slotmem/mod_cluster_slotmem configuration
 
-The actual version does not require any configuration directives.
+The current version does not require any configuration directives.
 
 == mod_proxy_cluster
 
 === CreateBalancers
 
-CreateBalancers define how balancers are created in the httpd VirtualHosts, this is to allow directives like:
+CreateBalancers define how balancers are created in the httpd VirtualHosts. This is to allow directives like:
 
 [source]
 ----
@@ -72,7 +73,10 @@ ProxyPass / balancer://mycluster1/
 NOTE: *CreateBalancers 1:* When using 1 don't forget to configure the balancer in the ProxyPass directive, because the default is
 empty stickysession and `nofailover=Off` and the values received via the MCMP CONFIG message are ignored.
 
-NOTE: *Default: 2* If you have no `ProxyPass` directive in the `VirtualHost`, the `VirtualHost` is ignored by mod_cluster. So, even if `CreateBalancers` is set to `2` (default), the main server is used instead in such configuration. See also https://issues.jboss.org/browse/MODCLUSTER-430[MODCLUSTER-430 &mdash; CreateBalancers behave the same with option 0 or 2]
+NOTE: *Default: 2* If you have no `ProxyPass` directive in the `VirtualHost`, the `VirtualHost` is ignored
+by mod_proxy_cluster. So, even if `CreateBalancers` is set to `2` (default), the main server is used instead
+in such configuration.
+See also https://issues.jboss.org/browse/MODCLUSTER-430[MODCLUSTER-430 &mdash; CreateBalancers behave the same with option 0 or 2]
 
 
 === UseAlias
@@ -97,15 +101,14 @@ The actual formula to recalculate the status of a node is:
 
 [source]
 ----
-status = lbstatus + (elected - oldelected) * 1000)/lbfactor;
+status = lbstatus + (elected - oldelected) * 1000) / lbfactor;
 ----
 
 lbfactor is received for the node via STATUS messages.lbstatus is recalculated every LBstatusRecalTime seconds using the formula:
-`lbstatus = (elected - oldelected) * 1000)/lbfactor`
+`lbstatus = (elected - oldelected) * 1000) / lbfactor`
 
-elected is the amount of time the worker has been elected. `oldelected` is `elected` last time the `lbstatus`
-was recalculated. The node with the lowest `status` is selected. Nodes with `lbfactor ≤ 0` are skipped by the both
-calculation logics.
+where `elected` is the amount of time the worker has been elected. `oldelected` is `elected` from the last time the `lbstatus`
+was recalculated. The node with the lowest `status` is selected. Nodes with `lbfactor ≤ 0` are skipped by the both calculation logics.
 
 === WaitForRemove
 
@@ -137,15 +140,19 @@ but for HTTP/HTTPS connections. The endpoint needs to implement at least HTTP/1.
 
 === AJPSecret
 
-Use `AJPSecret your_secret` to provide the secret for the AJP back-end, See mod_proxy_ajp and mod_proxy docs for more information. If `your_secret` doesn't correspond to the value configured in the back-end the back-end will return 503 to any request coming through the proxy.
+Use `AJPSecret your_secret` to provide the secret for the AJP back-end, See mod_proxy_ajp and mod_proxy docs for more
+information. If `your_secret` doesn't correspond to the value configured in the back-end the back-end will return 503
+to any request coming through the proxy.
 
 === WSUpgradeHeader
 
-Use `WSUpgradeHeader value` to define the value of the upgrade header mod_proxy_wstunnel is accepting. See mod_proxy_wstunnel and mod_proxy docs for more information.
+Use `WSUpgradeHeader value` to define the value of the upgrade header mod_proxy_wstunnel is accepting. See
+mod_proxy_wstunnel and mod_proxy docs for more information.
 
 === ResponseFieldSize
 
-Size in bytes of the HTTP/1.1 buffers of the workers, the default size is 8192, that limits the header size a webapp can use (Note: In Tomcat there is  maxHttpHeaderSize that also limits it in the Connector).
+Size in bytes of the HTTP/1.1 buffers of the workers, the default size is 8192, that limits the header size a webapp
+can use (Note: In Tomcat there is  maxHttpHeaderSize that also limits it in the Connector).
 
 === CacheShareFor
 
@@ -158,11 +165,12 @@ VirtualHost configuration. If not an error message will be displayed and httpd w
 
 === EnableMCPMReceive
 
-EnableMCPMReceive &mdash; allow the VirtualHost to receive mod_cluster management protocol (MCMP) messages. You need one
-EnableMCPMReceive in your httpd configuration to allow mod_cluster to
-work, put it in the VirtualHost where you configure advertise.
+EnableMCPMReceive &mdash; allow the VirtualHost to receive Mod-Cluster Management Protocol (MCMP) messages. You need one
+EnableMCPMReceive in your httpd configuration to allow mod_proxy_cluster to work, put it in the VirtualHost where you
+configure advertise.
 
-This directive was added so as to address the issue of receiving MCMP on arbitrary VirtualHosts which was problematic due to accepting messages on insecure, unintended VirtualHosts.
+This directive was added so as to address the issue of receiving MCMP on arbitrary VirtualHosts which was problematic
+due to accepting messages on insecure, unintended VirtualHosts.
 
 === MemManagerFile
 
@@ -177,7 +185,7 @@ files are placed on a local drive and not an NFS share. (Context: **server confi
 
 === Maxcontext
 
-The maximum number of application contexts supported by mod_cluster. (Context: **server config**)
+The maximum number of application contexts supported by mod_proxy_cluster. (Context: **server config**)
 
 **Default:**
 ++++
@@ -186,7 +194,7 @@ The maximum number of application contexts supported by mod_cluster. (Context: *
 
 === Maxnode
 
-That is the maximum number of nodes supported by mod_cluster. (Context: **server config**)
+That is the maximum number of nodes supported by mod_proxy_cluster. (Context: **server config**)
 
 **Default:**
 ++++
@@ -195,7 +203,8 @@ That is the maximum number of nodes supported by mod_cluster. (Context: **server
 
 === Maxhost
 
-That is the maximum number of hosts (Aliases) supported by mod_cluster. That is also the max number of balancers. (Context: **server config**)
+That is the maximum number of hosts (Aliases) supported by mod_proxy_cluster. That is also the max number of balancers.
+(Context: **server config**)
 
 **Default:**
 ++++
@@ -231,7 +240,7 @@ Default: mycluster
 
 === PersistSlots
 
-PersistSlots: Tell mod_slotmem to persist the nodes, Alias and Context
+PersistSlots: Tell mod_cluster_slotmem to persist the nodes, Alias and Context
 in files. (Context: server config)
 
 Default: Off
@@ -267,7 +276,7 @@ Default: off Full information displayed
 === SetHandler mod_cluster-manager
 
 SetHandler mod_cluster-manager: That is the handler to display the node
-mod_cluster sees from the cluster. It displays the information about
+mod_proxy_cluster sees from the cluster. It displays the information about
 the nodes like INFO and additionally counts the number of active
 sessions.
 
@@ -301,26 +310,28 @@ Note that:
 Transferred: Corresponds to the POST data send to the back-end server.
 
 Connected: Corresponds to the number of requests been processed when the
-mod_cluster status page was requested.
+mod_proxy_cluster status page was requested.
 
-sessions: Corresponds to the number of sessions mod_cluster report as
+sessions: Corresponds to the number of sessions mod_proxy_cluster report as
 active (on which there was a request during the past 5 minutes). That
 field is not present when Maxsessionid is zero.
 
 === mod_advertise
 
-mod_advertise uses multicast packets to advertise the VirtualHost where it is configured that must be the same VirtualHost
-where mod_manager is defined. Of course at least one mod_advertise must be in the VirtualHost to allow mod_cluster to find
-the right IP and port to give to the ClusterListener.
+mod_advertise uses multicast packets to advertise the VirtualHost where it is
+configured that must be the same VirtualHost where mod_manager is defined. Of
+course at least one mod_advertise must be in the VirtualHost to allow
+mod_proxy_cluster to find the right IP and port to give to the ClusterListener.
 
 === ServerAdvertise
 
 ServerAdvertise On: Use the advertise mechanism to tell the JBoss
 AS/JBossWeb/Tomcat to whom it should send the cluster information.
 
-ServerAdvertise On http://hostname:port: Tell the hostname and port to use. Only needed if the VirtualHost is not defined
-correctly, if the VirtualHost is a http://httpd.apache.org/docs/2.2/vhosts/name-based.html[Name-based Virtual Host] or when
-VirtualHost is not used.
+ServerAdvertise On http://hostname:port: Tell the hostname and port to use.
+Only needed if the VirtualHost is not defined correctly, if the VirtualHost is
+a http://httpd.apache.org/docs/2.2/vhosts/name-based.html[Name-based Virtual Host]
+or when VirtualHost is not used.
 
 ServerAdvertise Off: Don't use the advertise mechanism.
 
@@ -369,7 +380,7 @@ Default: 0.0.0.0:23364
 Beware of the different names of `mod_cluster_slotmem.so` and `mod_slotmem.so` between mod_cluster 1.3.x and older versions.
 Last but not least, pay attention to httpd 2.2.x and httpd 2.4.x authentication configuration changes.
 
-=== mod_cluster 1.3.x, Apache HTTP Server 2.4.x
+=== mod_cluster 1.3.x and newer, Apache HTTP Server 2.4.x
 
 [source]
 ----
@@ -445,23 +456,30 @@ LoadModule advertise_module modules/mod_advertise.so
 
 == Building httpd modules
 
-mod_cluster 1.3.x and older, both httpd modules and Tomcat/WildFly java libraries reside in the https://github.com/modcluster/mod_cluster[mod_cluster] repository, branches 1.3.x and 1.2.x. New development of mod_cluster httpd modules takes place in the new repository: https://github.com/modcluster/mod_proxy_cluster[mod_proxy_cluster].
+mod_cluster 1.3.x and older, both httpd modules and Tomcat/WildFly java libraries reside in the
+https://github.com/modcluster/mod_cluster[mod_cluster] repository, branches 1.3.x and 1.2.x. New
+development of mod_cluster httpd modules takes place under a new name mod_proxy_cluster in the
+new repository https://github.com/modcluster/mod_proxy_cluster[mod_proxy_cluster].
 
-See https://asciinema.org/a/7563u1eu6o5jlg3a0gk4wv69f?t=52[ASCII recorded tutorial] on httpd modules compilation with your own system httpd.
+See https://asciinema.org/a/7563u1eu6o5jlg3a0gk4wv69f?t=52[ASCII recorded tutorial] on httpd modules
+compilation with your own system's httpd.
 
 === Build with httpd on Windows
 
-We assume you already have a functional Apache HTTP Server on Windows. This example works with Apache Lounge HTTP Server.
-We also assume the system has MS Visual Studio (Community Edition is ample) and CMake installed. The example operates in cmder shell, but it is not mandatory. A simple Windows cmd prompt would work too.
+We assume you already have a functional Apache HTTP Server on Windows. This example works with
+Apache Lounge HTTP Server.
+We also assume the system has MS Visual Studio (Community Edition is ample) and CMake installed.
+The example operates in cmder shell, but it is not mandatory. A simple Windows cmd prompt would work too.
 
- * Download the http://www.apachelounge.com/download/[Apache Lounge distribution]. Our example uses http://www.apachelounge.com/download/VC14/binaries/httpd-2.4.23-win64-VC14.zip[httpd-2.4.23-win64-VC14.zip].
+ * Download the https://www.apachelounge.com/download/[Apache Lounge distribution]. Our example uses
+   https://www.apachelounge.com/download/VS17/binaries/httpd-2.4.55-win64-VS17.zip[httpd-2.4.55-win64-VS17.zip].
  * unzipped:
 
 [source]
 ----
 C:\Users\karm
 ls
-httpd-2.4.23-win64-VC14/ httpd-2.4.23-win64-VC14.zip
+httpd-2.4.55-win64-VS17/ httpd-2.4.55-win64-VS17.zip
 ----
 
  * Clone mod_proxy_cluster sources git:
@@ -487,7 +505,8 @@ C:\Users\karm\mod_proxy_cluster\native\build (main)
 vcvars64.bat
 ----
 
-Here comes the only slightly tricky part: Apache Lounge httpd ships all necessary *.lib files with exported symbols but for mod_proxy. Since mod_proxy is our dependency, we have to generate these exported symbols from mod_proxy dll.
+Here comes the only slightly tricky part: Apache Lounge httpd ships all necessary *.lib files with exported symbols but
+for mod_proxy. Since mod_proxy is our dependency, we have to generate these exported symbols from mod_proxy dll.
 
 [source]
 ----
@@ -570,12 +589,13 @@ Rebuild (make) and reinstall (make install) after that.
 You need an httpd installation with mod_proxy (`--enable-proxy`) and ajp
 protocol (`--enable-proxy-ajp`) enabled and with dso enabled (`--enable-so`).
 
-Download the mod_cluster sources:
+Download the mod_proxy_cluster sources:
 
-    git clone git://github.com/modcluster/mod_cluster.git
+    git clone git://github.com/modcluster/mod_proxy_cluster.git
 
-Build the mod_cluster modules components, for each subdirectory
-advertise, mod_manager, mod_proxy_cluster and mod_slotmem do
+Build the mod_proxy_cluster's modules components, for each subdirectory
+advertise, mod_manager, mod_proxy_cluster and mod_cluster_slotmem (mod_slotmem
+for version 1.2 or older) do
 something like:
 
 [source,bash]
@@ -596,11 +616,11 @@ NOTE: You can ignore the libtool message on most platform:
 libtool: install: warning: remember to run `libtool --finish apache_installation_directory/modules'
 ----
 
-Once that is done use Apache httpd configuration to configure mod_cluster.
+Once that is done use Apache httpd configuration to configure mod_proxy_cluster.
 
 === Build the mod_proxy module
 
-It is only needed for httpd-2.2.x where x \< 11. Process like the other mod_cluster modules.
+It is only needed for httpd-2.2.x where x \< 11. Process like the other mod_proxy_cluster modules.
 
 == Installing httpd modules
 

--- a/docs/src/main/asciidoc/quickstart.adoc
+++ b/docs/src/main/asciidoc/quickstart.adoc
@@ -2,56 +2,58 @@
 
 NOTE: {editurl}quickstart.adoc[{editnote}]
 
-The following are the steps to set up a minimal working installation of
+Following are the steps to set up a minimal working installation of
 mod_cluster on a single httpd server and a single back end server,
 either JBoss AS, JBossWeb, Undertow or Tomcat. The steps can be repeated to add as
-many httpd servers or back end servers to your cluster as is desired.
+many httpd servers or back end servers to your cluster as desired.
 
-The steps shown here are not intended to demonstrate how to set up a production install of mod_cluster;
-for example link:#UsingSSL[using SSL to secure access] to the httpd-side mod_manager component is not covered. See the
-link:#balancer_config[balancer-side] and
-link:#worker_config[worker-side] configuration documentation for the full set of configuration options.
+The steps shown here are not intended to demonstrate how to set up a production
+install of mod_proxy_cluster; for example, link:#UsingSSL[using SSL to secure
+access] to the httpd-side mod_manager component is not covered. See the
+link:#balancer_config[balancer-side] and link:#worker_config[worker-side]
+configuration documentation for the full set of configuration options.
 
 == Download mod_cluster components
 
 Download the latest httpd and java release bundles.
 If there is no pre-built httpd bundle appropriate for your OS or system architecture,
-you can link:#building-httpd-modules[build the Apache httpd binary from source].
+you can link:#building-httpd-modules[build the Apache httpd binary from the source].
 
 == Install the httpd binary
 
 === Install the whole httpd
 
-Most of the standard distribution contains Apache httpd server. Use your platform specific install tools to install.
-For example in fedora. Just install as in root, e.g.
+Most of the standard distributions contain Apache httpd server. Use your platform's
+specific install tools to install. For example, in Fedora, just install as a root:
 
 [source,bash]
 ----
-cd /tmp
-yum install httpd
+dnf install httpd
 ----
 
 === Install only the mod_cluster modules
 
 If you already have a working httpd install that you would prefer to
-use and your distribution contains mod_cluster or mod_proxy_cluster just install it.
+use and your distribution contains mod_cluster/mod_proxy_cluster just install it:
 
 [source,bash]
 ----
-cd /tmp
-yum install mod_cluster
+dnf install mod_cluster
 ----
 
-And then you have the files below to your module directory:
+And then you have the files below in your module directory:
 
 * mod_cluster_slotmem.so
 * mod_manager.so
 * mod_proxy_cluster.so
 * mod_advertise.so
 
-*httpd version mismatch:* `[warn] httpd version mismatch detected` Please, beware that one cannot simply load the aforementioned modules into an arbitrary httpd installation.
-These modules were built with a particular minor httpd version and they cannot be used with an older one.
-For instance, mod_cluster modules built with httpd 2.4.x cannot be loaded into httpd 2.2.x.
+*httpd version mismatch:* `[warn] httpd version mismatch detected` Please,
+beware that one cannot simply load the aforementioned modules into an arbitrary
+httpd installation. These modules were built with a particular minor httpd
+version, and they cannot be used with an older one. For instance,
+mod_proxy_cluster modules built with httpd 2.4.x cannot be loaded into httpd
+2.2.x.
 
 === Install in Windows
 


### PR DESCRIPTION
I went through the docs and tried to fix old naming (proxy_cluster, slotmen), link to GitHub, and a few of what I believe were language errors.

I went through the Windows example where I updated the links to the current Apache (and checked that it works on the newest Windows).