### PR TITLE
ci: Skip Deploy workflow on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'modcluster'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
It's annoying that the CI fails in forks for Deploy job. This change prevents the job from running in forks.