### PR TITLE
Fix bad addressttl parameter record in migration table

### DIFF
--- a/docs/src/main/asciidoc/migration.adoc
+++ b/docs/src/main/asciidoc/migration.adoc
@@ -85,7 +85,7 @@ only the balancers and the workers definitions are slightly different.
 | route | JVMRoute | In fact JBossWEB via the JVMRoute in the Engine will add it
 | status | - | mod_cluster has a finer status handling: by context via the ENABLE/STOP/DISABLE/REMOVE application messages. hot-standby is done by lbfactor = 0 and Error by lbfactor = 1 both values are sent in STATUS message by the ClusterListener
 | timeout | nodeTimeout | Default wait forever (http://httpd.apache.org/docs/2.4/mod/mod_proxy.html[http://httpd.apache.org/docs/2.4/mod/mod_proxy.html] is wrong there)
-| ttl | ttl | Default 60 seconds
+| addressttl | - | Default 60 seconds
 |===
 
 === Balancers


### PR DESCRIPTION
https://docs.modcluster.io/#workers

The second ttl is addressttl and is not configurable at this time.

See

https://github.com/modcluster/mod_proxy_cluster/blob/a18682687905fe2d16b12c3d23e8269f98690081/native/mod_proxy_cluster/mod_proxy_cluster.c#L455

and

https://httpd.apache.org/docs/current/mod/mod_proxy.html#proxypass